### PR TITLE
Fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Aviation Framework
 
-This is the Aviation Framework for Roblox which helps to keep communication between client and server and vice versa organised and well maintained. Also known as 'hypixel26's Custom RemoteFramework'.
+This is the Aviation Framework for Roblox which helps to keep communication between client and server and vice versa organised and well maintained. Formerly known as 'hypixel26's Custom RemoteFramework'.
 
 ## Installation Process
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 
 ## Introduction
 
-> **What's Aviation?**
+> **What is Aviation?**
 
 Aviation is a library and *partial framework* designed for Roblox and is meant to replace the *direct usage* of RemoteEvent and RemoteFunction. It helps to keep communication between client and server, and vice versa organised while being well maintained. Aviation was formerly known as 'hypixel26's Custom RemoteFramework', and is provided to you by [Frieda_VI](https://www.roblox.com/users/479498903/profile).
 
@@ -11,9 +11,9 @@ Aviation is a library and *partial framework* designed for Roblox and is meant t
 
 > **Why Aviation?**
 
-Aviation was designed to be used as a remote filler but why use it? Each players have their own set of RemoteObjects, all having a uniform name, and changing properties of the RemoteObject will result in a `#!lua Player:Kick()`. It helps to keep your code organised, efficient and exploit prof.
+Aviation was designed to be used as a remote filler, but why use it? Each player has their own set of RemoteObjects, all having a uniform name. Changing properties of the RemoteObjects will result in a `#!lua Player:Kick()`. It helps to keep your code organised, efficient and exploit proof.
 
-Aviation is not for everyone, I expect people who are good at managing their codes and RemoteEvents|Functions to be using Aviation.
+Aviation is not for everyone, I expect people who are good at managing their code and RemoteEvents|Functions to be using Aviation.
 
 
 ```lua hl_lines="2"
@@ -22,4 +22,4 @@ while true do
 end
 ```
 
-If your game is coded like the code above, that is the **overly** usage of RemoteEvent|Function, I'd suggest you stay away from Aviation as this style of coding is not efficient at all, and is to be avoided.
+If your game is coded similarly to the code above, and **excessively** uses RemoteEvents|Functions, I'd suggest you stay away from Aviation, as this style of coding is not efficient at all, and is to be avoided.

--- a/docs/pages/Api/Client.md
+++ b/docs/pages/Api/Client.md
@@ -1,13 +1,13 @@
 
 # Client Functions of Aviation
 
-Getting the PlayerStructure and Getting RemoteObjects were discussed and explained in *#Sever_and_Client*. So we'll be basing our understanding from there.
+Getting the PlayerStructure and RemoteObjects were discussed and explained in *#Sever_and_Client*. So we'll be basing our understanding from there.
 
 ---
 
 ## Securise
 
-Right after obtaining the *PlayerObject* on the Main Client Runtime, you should call the `:Securise` method. The *Securise* method ensure that the RemoteInstances are exploit prof on the ClientSide.
+Right after obtaining the *PlayerObject* on the Main Client Runtime, you should call the `:Securise` method. The *Securise* method ensures that the RemoteInstances are exploit proof on the client side.
 
 ```lua hl_lines="6-7"
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -22,7 +22,7 @@ PlayerStructure:Securise()
 
 ## Attaching Functions
 
-Not all *RemoteObjects* will have functions attached to them as some will be used to __Invoke__ the server. The method demonstrated is a primitive way to attach functions to remotes is not very efficient when used as such but it can still be used sometimes. `:BindToClient()` methods takes in a function which will receive arguments sent by the server. As *RemoteObjects* are two way communication devices they allow the `return` of data back to the Server.
+Not all *RemoteObjects* will have functions attached to them, some will be used to __Invoke__ the server. The method demonstrated is a primitive way to attach functions to remotes and is not very efficient, but can still be used sometimes. `:BindToClient()` methods takes in a function which will receive arguments sent by the server. As *RemoteObjects* are two way communication devices they allow the `return` of data back to the Server.
 
 
 ``` lua hl_lines="2-5"
@@ -37,13 +37,13 @@ Not all *RemoteObjects* will have functions attached to them as some will be use
     end)
 ```
 
-## Efficient Attaching Functions
+## Efficiently Attaching Functions
 
-Just like the on the Server we have *RemoteList*, on the client too we have *RemoteList*.
+Just like how on the Server we have RemoteList, the client has it too.
 
-The way to bind functions to RemoteObjects below is the most efficient and recommended way. *RemoteList* is a table, you can have creation of RemoteObjects and attach functions to them all in a module and provide it to the *PlayerObject* to consume. 
+The way to bind functions to RemoteObjects below is the most efficient and recommended way. RemoteList is a table, you can have creation of RemoteObjects and attach functions to them all in a module and provide it to the PlayerObject to consume.
 
-The `:FromStructure()` method takes the *RemoteList* as argument and binds function to the following RemoteObject. The *RemoteList* is a table"Dictionary", all the __indexes__ are RemoteObject's name and __values__ are functions that are attached to the RemoteObject and called when the RemoteObject is fired from the Server.
+The :FromStructure() method takes the RemoteList as argument and binds function to the following RemoteObject. The RemoteList is a table "Dictionary", all the indexes are RemoteObject's name and values are functions that are attached to the RemoteObject and called when the RemoteObject is fired from the Server.
 
 ```lua hl_lines="1-6 14"
 local Aviation = require(ReplicatedStorage:WaitForChild("Aviation"))
@@ -58,5 +58,4 @@ local RemoteList = {
 }
 
 PlayerObject:FromStructure(RemoteList)
-end)
 ```

--- a/docs/pages/Api/Collapser.md
+++ b/docs/pages/Api/Collapser.md
@@ -10,7 +10,7 @@ Collapser is an extremely useful feature as it is a way of communicating with th
 
 ### Code Sampling
 
-Here are some basic example on how the Collapser is meant to be used:
+Here are some basic examples showing how the Collapser is meant to be used:
 
 ```lua
 --// This Is Our Sample Code \\--
@@ -61,12 +61,12 @@ local RemoteList = {
 }
 ```
 
-The `Example3` RemoteObject is the perfect example of how to set and create a Collapser for a RemoteObject. It is similar to the Stable Method of creating RemoteObject with the expection that it takes in a table instead of a function. The dictionary (table) should only contain two indexes, `Callback` and `Collapser`. 
+The `Example3` RemoteObject is a perfect example of how to set and create a Collapser for a RemoteObject. It is similar to the Stable Method of creating RemoteObject with the expection that it takes in a table instead of a function. The dictionary should only contain two indexes, `Callback` and `Collapser`. 
 
 The `Callback` is the regular function binded to the RemoteObject, like for `Example2`.
 The `Collapser`, on the other hand provides a function which will be called when the `PlayerStructure.Collapse` method is called. **Note: The Collapser Method should not yield!**
 
-There are two different methods of calling the Collapse method but they both function in the same manner. **Note: It is recommended that the Collapse method be called only when the Player is leaving, as Collapse is sign of Destroy.** However the Collapse method, doesn't have destroying capacities, and will not affect the AviationObject.
+There are two different methods of calling the Collapse method but they both function in the same manner. **Note: It is recommended that the Collapse method be called only when the Player is leaving, as Collapse is sign of Destroy.** However the Collapse method doesn't have destroying capabilities, and will not affect the AviationObject.
 
 ```lua hl_lines="6 8"
 --// This Expands Upon The Sample Code And All Previous Code From Above \\--
@@ -86,12 +86,12 @@ end)
 
 This is the first method of calling the Collapse method, and there exists two methods of performing the task. This first method aims at calling all RemoteObject's Collapser and takes a boolean `true` as argument.
 
-Both methods of Collapsing has the overall same type of returning mechanism, however the second method has a unique function which aims to make finding the returned values easier. The returned values of each RemoteObject is sealed in a table, and this table is then sealed into another general table containing all the returned values with the RemoteObject name as indexer. That means that Example3's collapser will have `Example3` as indexer.
+Both methods of collapsing has the overall same type of returning mechanism, however the second method has a unique function which aims to make finding the returned values easier. The returned values of each RemoteObject is sealed in a table, and this table is then sealed into another general table containing all the returned values with the RemoteObject name as indexer. That means that Example3's collapser will have `Example3` as indexer.
 
 Representation of the return[1] format: `{ Example3 = { "Example3" }, SampleExample = { "SampleExampleString", 2, true } }`. Any values returned will be orderly arranged in the table. 
 
 ```lua hl_lines="6 8"
---// This Expands Upon The Sample Code And All Previous Code From Above \\--
+--// This expands upon the sample code and all previous code from above \\--
 
 Players.PlayerRemoving:Connect(function(Player)
     local PlayerStructure = PlayerStructures[Player]
@@ -101,15 +101,15 @@ Players.PlayerRemoving:Connect(function(Player)
         print(Returns.Example3[1], Returns.Get(1), Returns.Get())
     end
 
-    --// Performing Garbage Collecting \\--
+    --// Performing garbage collecting \\--
     PlayerStructures[Player] = nil
 end)
 
 ```
 
-The second method of collapsing is specific to 1 Indexer. Instead of a boolean `true` being provided as argument, it takes a specific string `Example3` as argument. This Indexer is then used to find the Collapser for the RemoteObject under the name of the Indexer.
+The second method of collapsing is specific to 1 Indexer. Instead of a boolean `true` being provided as argument, it takes a specific string `Example3` as argument. This indexer is then used to find the collapser for the RemoteObject under the name of the Indexer.
 
-All the returned values are stored similarly to the first method. But with only one RemoteObject's Collapser being called, there's only going to be one returned table. Therefore, the return table for the second method offers a `.Get` method which takes a number as parameter. This number is then used to obtain the returned value according to the order returned, if left blank, it returns the first returned value of the Collapse method.
+All the returned values are stored similarly to the first method. But with only one RemoteObject's collapser being called, there's only going to be one returned table. Therefore, the return table for the second method offers a `.Get` method which takes a number as parameter. This number is then used to obtain the returned value according to the order returned, if left blank, it returns the first returned value of the Collapse method.
 
 That's about it all on Collapser.
 
@@ -138,8 +138,8 @@ Players.PlayerAdded:Connect(function(Player)
 end
 ```
 
-The `.GetStructure` method is a short and more performant way of obtaining the original PlayerStructure created. This doesn't aim at replace the classical `.Structure` method which also takes `Player` as argument but simply aims at providing more accesibility.
+The `.GetStructure` method is a short and more performant way of obtaining the original PlayerStructure created. This doesn't aim at replace the classical `.Structure` method which also takes `Player` as argument, but simply aims at providing more accessibility.
 
-`.GetStructure` and `.Structure` do not perform the same. `GetStructure` is only available on the server and it provides the original AviationObject created whilst `.Structure` is available on both the client and the server but it provides a modified AviationObject which doesn't directly inherrit from the Aviation class.
+`.GetStructure` and `.Structure` do not perform the same. `GetStructure` is only available on the server and it provides the original AviationObject created whilst `.Structure` is available on both the client and the server, but it provides a modified AviationObject which doesn't directly inherit from the Aviation class.
 
 **Keep in mind that both methods do provide the Collapsing feature.**

--- a/docs/pages/Api/Server.md
+++ b/docs/pages/Api/Server.md
@@ -15,7 +15,7 @@ local Aviation = require(ReplicatedStorage:WaitForChild("Aviation"))
 Aviation.Start()
 ```
 
-The `.Start()` method should only be called ONCE by a ServerScript. It's meant to initialise core compoenents of Aviation and to get it to run thus marking it's name to **start**.
+The `.Start()` method should only be called ONCE by a ServerScript. It's meant to initialise and run core components of Aviation.
 
 ``` lua hl_lines="3"
 --// Random Server Script \\-- 
@@ -28,9 +28,9 @@ All ServerScripts using Aviation SHOULD call the `.Await()` function on Aviation
 
 ## RemoteObject Creation
 
-RemoteObjects are two way conversation objects meaning they inherrit from *RemoteFunctions* directly. The creation of RemoteObjects should be wrapped by the `.PlayerAdded` event, and it is one of the most important features that the Server provides.The examples below assumes that we are using the code above demonstrating how to *start* Aviation
+RemoteObjects are two way conversation objects meaning they inherit from *RemoteFunctions* directly. The creation of RemoteObjects should be wrapped by the `.PlayerAdded` event, and it is one of the most important features that the Server provides. The examples below assumes that we are using the code above demonstrating how to *start* Aviation
 
-In order to creat RemoteObjects, we need an AviationObject on which RemoteObject creation can be performed.
+In order to create RemoteObjects, we need an AviationObject on which RemoteObject creation can be performed.
 
 ### AviationObject Creation
 
@@ -56,7 +56,7 @@ Since the *AviationObject* is dedicated to a Player, we can call it a **PlayerOb
 
 Now that we have our *PlayerObject*, we can begin creating remotes which should be done before processing `PlayerObject:Process()` the *PlayerObject*.
 
-The method demonstrated below is a primitive method, and is not recommended to be used directly but it is important to learn how Aviation functions in order to properly use it. Later on you will learn about a more efficient method at creating *RemoteObjects* and attaching functions to them. The `:NewRemote()` method takes the Remote's name as argument and returns a RemoteObject, which functions can be attached to. The code below assumes that you're using the codes above to create the *PlayerObject*.
+The method demonstrated below is a primitive method, and is not recommended to be used directly, but it is important to learn how Aviation functions in order to properly use it. Later on you will learn about a more efficient method to creating *RemoteObjects* and attaching functions to them. The `:NewRemote()` method takes the Remote's name as argument and returns a RemoteObject, which functions can be attached to. The code below assumes that you're using the codes above to create the *PlayerObject*.
 
 ``` lua hl_lines="1"
     local FriedaRemote = PlayerObject:NewRemote("FriedaRemote")
@@ -66,7 +66,7 @@ The method demonstrated below is a primitive method, and is not recommended to b
 
 ### Attaching Functions
 
-Not all *RemoteObjects* will have functions attached to them as some will be used to __Invoke__ the client. The method demonstrated is a primitive way to attach functions to remotes is not very efficient when used as such but it can still be used sometimes. `:BindToServer()` methods takes in a function and feed it the Player as the first argument, and all the arguments provided by the client. *RemoteObjects* are two way communication devices, meaning they can `return` data back to the client.
+Not all *RemoteObjects* will have functions attached to them as some will be used to __Invoke__ the client. The method demonstrated is a primitive way to attach functions to remotes is not very efficient, but it can still be used sometimes. `:BindToServer()` methods takes in a function and feed it the Player as the first argument, and all the arguments provided by the client. *RemoteObjects* are two way communication devices, meaning they can `return` data back to the client.
 
 > All functions MUST be attached to their RemoteObjects before processing the *PlayerObject*.
 
@@ -84,7 +84,7 @@ Not all *RemoteObjects* will have functions attached to them as some will be use
 
 The way to create RemoteObjects and attach functions to them below is the most efficient and recommended way. *RemoteList* is a table, you can have create RemoteObjects and attach functions to them all in a module and provide it to the *PlayerObject* to consume. 
 
-The `:FromList()` method takes the *RemoteList* as argument and construct *RemoteObjects* based on the list provided and should be called before processing the PlayerObject. The *RemoteList* is a table"Dictionary", all the __indexes__ are RemoteObject's name and __values__ are functions that are going to call when the RemoteObject is fired, which is an optional field.
+The `:FromList()` method takes the *RemoteList* as argument and construct *RemoteObjects* based on the list provided and should be called before processing the PlayerObject. The *RemoteList* is a table "Dictionary", all the __indexes__ are RemoteObject's name and __values__ are functions that are going to call when the RemoteObject is fired, which is an optional field.
 
 ```lua hl_lines="1-7 14"
 local RemoteList = {
@@ -106,18 +106,18 @@ Players.PlayerAdded:Connect(function(Player)
 end)
 ```
 
-### Fire all Client
+### Fire all Clients
 
 Firing a specific Client on the Server needs a player from which you'll retrive the *PlayerStructure* and call the `:FireClient` method on. The `:FireClient` method does **not** consume a Player. What about firing all the Remotes of a Player?
 
-The `:FireAll` method is called directly on Aviation and takes the RemoteObject name that is to be fired as first argument and the rest of the arguments are passed. This method returns a table of all the PlayerResponces if there were any.
+The `:FireAll` method is called directly on Aviation and takes the RemoteObject name that is to be fired as first argument and the rest of the arguments are passed. This method returns a table of all the PlayerResponses if there were any.
 
-How the PlayerResponces is structured, `{PlayerName = {Data, Data, ...}}`.
+PlayerResponses is structured like this: `{PlayerName = {Data, Data, ...}}`.
 
 
 ```lua hl_lines="2"
 local Aviation = require(ReplicatedStorage:WaitForChild("Aviation"))
-local PlayerResponces = Aviation:FireAll("Messenger", "Hello world from Aviation!")
+local PlayerResponses = Aviation:FireAll("Messenger", "Hello world from Aviation!")
 
-print("Frieda responded with", table.unpack(PlayerResponces["Frieda_VI"]))
+print("Frieda responded with", table.unpack(PlayerResponses["Frieda_VI"]))
 ```

--- a/docs/pages/Api/ServerClient.md
+++ b/docs/pages/Api/ServerClient.md
@@ -1,12 +1,12 @@
 
-# Shares Functions
+# Shared Functions
 
 > What are Shared Functions 
-Shared functions are those functions which are available on both the Server and the Client but they might not function the same.
+Shared functions are functions which are available on both the server and client, but they might not function the same.
 
 ## Await
 
-The `.Await()` method is an incontournable function which can be used by the Server or Client. To avoid errors, you should __ALWAYS__ use the `.Await()` before making your first reference to functions concerning Aviation.
+The `.Await()` method is an incontournable function which can be used by the server or client. To avoid errors, you should __ALWAYS__ use the `.Await()` before making your first reference to functions concerning Aviation.
 
 ```lua hl_lines="2"
 local Aviation = require(ReplicatedStorage:WaitForChild("Aviation"))
@@ -46,7 +46,7 @@ local FriedaRemote = PlayerStructure:GetRemote("FriedaRemote")
 
 ## Firing the Server | Client
 
-Firing the Server or Client is as simple as saying `RemoteObject:FireClient(Args)` or `RemoteObject:FireServer(Args)`, the fire methods can be given any arguments and will return data sent by the Server|Client. The `:FireClient()` method does NOT need the Player to be sent as argument.
+Firing the Server or Client is as simple as saying `RemoteObject:FireClient(Args)` or `RemoteObject:FireServer(Args)`, the fire methods can be given any arguments and will return data sent by the Server|Client. The `:FireClient()` method does NOT need the Player to be sent as an argument.
 
 
 === "Server"

--- a/docs/pages/Shared/Installation.md
+++ b/docs/pages/Shared/Installation.md
@@ -3,11 +3,11 @@
 
 ## Installation Process
 
-Aviation supports both the **Roblox Studio** and [**Rojo**](https://rojo.space/docs/v6/) workflows. It is quite simple and straight forward to install Aviation.
+Aviation supports both the **Roblox Studio** and [**Rojo**](https://rojo.space/docs/v6/) workflows. It is quite simple and straightforward to install Aviation.
 
 > **NOTE**
 
-__Aviation should always be in *ReplicatedStorage* and the file names should NEVER changed.__
+__Aviation should always be in *ReplicatedStorage* and the file names should NEVER be changed.__
 
 
 >Visual Studio Code and ROJO Workflow:

--- a/docs/pages/Shared/Tour.md
+++ b/docs/pages/Shared/Tour.md
@@ -19,7 +19,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Aviation = require(ReplicatedStorage:WaitForChild("Aviation"))
 local Signal = Aviation.Signal
 
-Aviation.Start() --// Should be called ONLY one time
+Aviation.Start() --// Should only be called ONCE
 
 
 local FriedaSignal = Signal.Wrap(function(Message)
@@ -59,12 +59,12 @@ end)
 
 > Client Code
 
-Demonstrate how to use Aviation on the client. Uses `:Securise` which helps to make your RemoteObjects exploit prof and not changable. 
+Demonstration of how to use Aviation on the client. Uses `:Securise` which helps to make your RemoteObjects exploit proof and not changeable. 
 Features used in the Client Code: 
 
-+ Securising RemoteObjects.
-+ RemoteObject and attaching functions to them.
-+ Firing RemoteObject.
++ Securing RemoteObjects.
++ Attaching functions to RemoteObjects.
++ Firing RemoteObjects.
 
 ```lua
 --// Main Client Runtime \\--
@@ -77,7 +77,7 @@ Aviation.Await()
 
 
 local PlayerStructure = Aviation.Structure()
-PlayerStructure:Securise() -- To be run once on the main Client runtime
+PlayerStructure:Securise() -- To be run once on the main client runtime
 
 
 PlayerStructure:FromStructure{

--- a/docs/pages/Utils/Signals.md
+++ b/docs/pages/Utils/Signals.md
@@ -1,7 +1,7 @@
 
 # Signal
 
-Signals allows you to have your own customised version of Roblox events which can receive callback functions. Signals works on both the Client and the Server and should be kept to the code where it was created. 
+Signals allow you to have your own customised version of Roblox events which can receive callback functions. Signals works on both the client and the server and should be kept to the code where it was created. 
 
 ```lua hl_lines="2 4-6 8"
 local Signals = Aviation.Signal
@@ -16,13 +16,13 @@ mySignal:Fire("Aviation signals are pog!")
 
 ## Creating Signals
 
-`Signal.new()` is the signal constructor which doesn't take any arguments and returns a SignalObject on which Callback functions can be attached.
+`Signal.new()` is a signal constructor and doesn't take any arguments. It returns a SignalObject on which Callback functions can be attached.
 
 ```lua
 local mySignal = Signal.new()
 ```
 
-Constructs a new Signal that wraps a function and returns a SignalObject, the SignalObject can then be mounted with more callback functions. Not that Wrap should only be called once, as it will create a new SignalObject.
+`Signal.Wrap()` constructs a new Signal that wraps a function and returns a SignalObject, the SignalObject can then be mounted with more callback functions. Not that Wrap should only be called once, as it will create a new SignalObject.
 
 ```lua hl_lines="1-3"
 local myConnection = Signal.Wrap(function(Message)
@@ -32,7 +32,7 @@ end)
 
 ## Destroying Signals
 
-SignalObjects have a `:Destroy()` method which will disconnect all the attached functions to the Signal and will attempt to clear the Signal. Thus rendering the following signal useless.
+SignalObjects have a `:Destroy()` method which will disconnect all the functions attached to the signal and will attempt to clear the signal. Thus rendering the signal useless.
 
 ```lua hl_lines="1"
 myConnection:Destroy()
@@ -40,7 +40,7 @@ myConnection:Destroy()
 
 ## Attaching Functions
 
-Functions can be attached to Signals, very simply. `:Connect()` takes in a callback function which will be call when a Signal is fired. Callback functions are allowed to yield and multiple callback functions can be attached to a SignalObject.
+Functions can be attached to signals very simply. `:Connect()` takes in a callback function which will be called when the signal is fired. Callback functions are allowed to yield and multiple callback functions can be attached to a SignalObject.
 
 ```lua hl_lines="1-3"
 myConnection:Connect(function(Message)
@@ -54,7 +54,7 @@ end)
 
 ## Fire Signals
 
-There are 3 ways of firing signals. Well be taking the `myConnection` for example.
+There are 3 ways of firing signals, `:Fire()`, `:FireSpawn()` and `:FireDefer()`.
 
 ### Fire
 
@@ -66,7 +66,7 @@ myConnection:Fire("Hello world")
 
 ### FireSpawn
 
-The `:FireSpawn()` function doesn't yield and uses `task.spawn`, which creates a new thread.
+The `:FireSpawn()` function doesn't yield and uses `task.spawn`, which runs the function asynchronously.
 
 ```lua hl_lines="1"
 myConnection:FireSpawn("Hello world")
@@ -74,7 +74,7 @@ myConnection:FireSpawn("Hello world")
 
 ### FireDefer
 
-The `:FireDefer()` function doesn't yield and uses `task.defer`, which can be used to achive a similar behaviour to `:FireSpawn`.
+The `:FireDefer()` function doesn't yield and uses `task.defer`, which works similarly to `:FireSpawn`.
 
 ```lua hl_lines="1"
 myConnection:FireDefer("Hello world")
@@ -82,9 +82,9 @@ myConnection:FireDefer("Hello world")
 
 
 ## Signal Checking
-Helps to check wether an object is a SignalObject or not.
+Helps to check whether an object is a SignalObject or not.
 
 ```lua hl_lines="2"
 local Signal = Aviation.Signal
-Vider.IsSignal(myVider) --> Proves wether object is a SignalObject or not: boolean
+Vider.IsSignal(myVider) --> Proves whether object is a SignalObject or not: boolean
 ```

--- a/docs/pages/Utils/Vider.md
+++ b/docs/pages/Utils/Vider.md
@@ -1,13 +1,13 @@
 
 # Vider
 
-Vider is a janitor module that uses french terms. It's recommended to avoid using *Vider* directly in your game as it's specific to Aviation. You could clone *Vider* and place it in *ReplicatedStorage* to use it.
+Vider is a janitor module that uses French terms. It's recommended to avoid using *Vider* directly in your game as it's specific to Aviation. You could clone *Vider* and place it in *ReplicatedStorage* to use it.
 
 ## Constructor
 
-`Vider.new()` is the vider constructor which doesn't take any arguments and return a ViderObject.
+`Vider.new()` is the constructor which doesn't take any arguments and returns a ViderObject.
 
-It is recommended to use `Vider:Debute()` instead of `Vider.new()`, *Debute* takes it a MainInstance and other which are considered as secondary instances. If the MainInstance is destroyed, it will trigger `Vider:Nettoyer` which is the cleaning up method. Other can only be RBXScriptConnection or Instances. *Debute* returns a ViderObject with the MainInstance as the controller and other arguments as secondary objects.
+It is recommended to use `Vider:Debute()` instead of `Vider.new()`. *Debute* takes in a MainInstance and other which are considered as secondary instances. If the MainInstance is destroyed, it will trigger `Vider:Nettoyer` which is the cleaning up method. Other can only be RBXScriptConnection or Instances. *Debute* returns a ViderObject with the MainInstance as the controller and other arguments as secondary objects.
 
 ```lua hl_lines="3-5"
 local Vider = Aviation.Vider
@@ -16,7 +16,7 @@ local myVider = Vider:Debute(workspace.Baseplate, workspace.Changed:Connect(func
     print(Child)
 end), workspace.Part) 
 
--- Vider only works with Instances 
+-- Vider only works with instances 
 ```
 
 ## Adding MainInstance
@@ -39,18 +39,18 @@ end))
 
 ## Cleaning
 
-ViderObjects will manually undergo the cleaning process after a MainInstance is destroyed but it is possible to force clean the ViderObject. The `:Nettoyer` method is called on the ViderObject will forcefully clean the the SecondaryInstance by default but if the boolean true is passed as argument, the MainInstances will also be destroyed.
+ViderObjects will manually undergo the cleaning process after a MainInstance is destroyed but it is possible to force clean the ViderObject. The `:Nettoyer` method is called on the ViderObject will forcefully clean the the SecondaryInstance by default, but if `true` is passed as argument, the MainInstances will also be destroyed.
 
 ```lua
-myVider:Nettoyer() -- Main Instance won't be destroy
+myVider:Nettoyer() -- Main Instances won't be destroyed
 myVider:Nettoyer(true) -- Main Instances will be destroyed
 ```
 
 ## Cleaning Functions
 
-There are 2 functions which are charged to run before and after cleaning.
+There are 2 functions which run before and after cleaning.
 
-`:AvantNet` method takes a callback function as argument and it will be call before cleaning the Instances, there can only be 1 *AvantNet* function.
+`:AvantNet` method takes a callback function as argument which will be called before cleaning the instances, there can only be 1 *AvantNet* function.
 
 ```lua hl_lines="1 5"
 myVider:AvantNet(function()
@@ -60,7 +60,7 @@ myVider:AvantNet(function()
 end)
 ```
 
-`:ApresNet` method takes a callback function as argument and it will be call after cleaning the Instances, there can only be 1 *ApresNet* function.
+`:ApresNet` method takes a callback function as argument which will be called after cleaning the instances, there can only be 1 *ApresNet* function.
 
 ```lua hl_lines="1 3"
 myVider:ApresNet(function()


### PR DESCRIPTION
I tried to fix as much of the broken grammar as possible but there were some cases where I wasn't sure about what you meant so I skipped those.

Some additional notes:
- I'm not even sure if "securise" is a word, I decided not to change it to "secure" because it's not my job to do that and it would introduce breaking changes
- Having all of Vider be in French is creative, for sure, but also very confusing for the average non-french person
- There was a lot of repetition between Server.md and Client.md
- The documentation is a little confusing at times, especially when it came to RemoteLists. In some cases it was hard to tell whether it was a part of Aviation or just a thing you should do.
- You never really explain *why* to use Aviation. In the introduction it just gives a vague description of what it does. Provide examples for when you could benefit from Aviation.

I probably forgot something but whatever